### PR TITLE
Add aliases for EAP versions of IDEs

### DIFF
--- a/SettingsDirectory.cpp
+++ b/SettingsDirectory.cpp
@@ -85,10 +85,14 @@ void SettingsDirectory::findCorrespondingDirectories(const QList<SettingsDirecto
 
 QMap<QString, QString> SettingsDirectory::getAliases() {
     return {
-            {"IntelliJ IDEA Community", "IdeaIC"},
-            {"IntelliJ IDEA Ultimate",  "IntelliJIdea"},
-            {"PyCharm Professional",    "PyCharm"},
-            {"PyCharm Community",       "PyCharmCE"},
+            {"IntelliJ IDEA Community",        "IdeaIC"},
+            {"IntelliJ IDEA Community EAP",    "IdeaIC"},
+            {"IntelliJ IDEA Ultimate",         "IntelliJIdea"},
+            {"IntelliJ IDEA Ultimate EAP",     "IntelliJIdea"},
+            {"PyCharm Professional",           "PyCharm"},
+            {"PyCharm Professional (EAP)",     "PyCharm"},
+            {"PyCharm Community",              "PyCharmCE"},
+            {"PyCharm Community EAP",          "PyCharmCE"},
             {"Android Studio (Canary Branch)", "AndroidStudioPreview"},
     };
 }


### PR DESCRIPTION
Some people do not use normal versions of ides, and only install the eap versions. This commit allows the jetbrains runner to find projects in such cases for these IDEs.

The values for alias names were taken from .desktop files from AUR packages (they are chosen by aur package maintainers and are contained in aur repos):

- https://aur.archlinux.org/packages/intellij-idea-ce-eap
- https://aur.archlinux.org/packages/intellij-idea-ue-eap
- https://aur.archlinux.org/packages/pycharm-eap
- https://aur.archlinux.org/packages/pycharm-community-eap

Fixes #6